### PR TITLE
DeviceOS: using windows instead of android

### DIFF
--- a/minecraft/protocol/login/data.go
+++ b/minecraft/protocol/login/data.go
@@ -97,7 +97,7 @@ type ClientData struct {
 	// this name is always '(Standard system devices) System devices'.
 	DeviceModel string
 	// DeviceOS is a numerical ID indicating the OS of the device.
-	DeviceOS protocol.DeviceOS
+	DeviceOS protocol.DeviceOS.DeviceWin10
 	// DeviceID is a UUID specific to the device. A different user will have the same UUID for this.
 	DeviceID string `json:"DeviceId"`
 	// GameVersion is the game version of the player that attempted to join, for example '1.11.0'.

--- a/minecraft/protocol/login/data.go
+++ b/minecraft/protocol/login/data.go
@@ -97,7 +97,7 @@ type ClientData struct {
 	// this name is always '(Standard system devices) System devices'.
 	DeviceModel string
 	// DeviceOS is a numerical ID indicating the OS of the device.
-	DeviceOS protocol.DeviceOS.DeviceWin10
+	DeviceOS protocol.DeviceWin10
 	// DeviceID is a UUID specific to the device. A different user will have the same UUID for this.
 	DeviceID string `json:"DeviceId"`
 	// GameVersion is the game version of the player that attempted to join, for example '1.11.0'.


### PR DESCRIPTION
will help bypass anti-toolbox checks